### PR TITLE
Reset the level counter when player wins

### DIFF
--- a/src/levels.inc
+++ b/src/levels.inc
@@ -29,7 +29,7 @@ check_next:
 	;; Check maximum level
 	ld (current_level), a
 	cp MAX_LEVEL
-	jp z, final
+	jp z, final_level
 	call win_snd
 	call slide_off
 
@@ -53,8 +53,11 @@ load_level:
 	call draw_buffer
 	call draw_ui
 	ret
-	
 
+final_level:
+        ld a, 0
+        ld (current_level), a
+        jp final
 
 level1:
 	incbin "levels/level1"


### PR DESCRIPTION
There was a bug where if the player ran the game again after winning the level counter was pointing past the level data into game code resulting in weird blank levels and eventually trying to play the title screen and crashing.